### PR TITLE
Pass tracker in schema for autoform frontend validation to work

### DIFF
--- a/generators/route/templates/schema.js
+++ b/generators/route/templates/schema.js
@@ -1,5 +1,6 @@
 import SimpleSchema from 'simpl-schema'
 import moment from 'moment'
+import { Tracker } from 'meteor/tracker'
 
 SimpleSchema.extendOptions(['autoform'])
 
@@ -30,4 +31,4 @@ export default new SimpleSchema({
       return moment().toDate()
     }
   }
-})
+}, { tracker: Tracker })

--- a/src/route/templates/schema.js
+++ b/src/route/templates/schema.js
@@ -1,5 +1,6 @@
 import SimpleSchema from 'simpl-schema'
 import moment from 'moment'
+import { Tracker } from 'meteor/tracker'
 
 SimpleSchema.extendOptions(['autoform'])
 
@@ -30,4 +31,4 @@ export default new SimpleSchema({
       return moment().toDate()
     }
   }
-})
+}, { tracker: Tracker })


### PR DESCRIPTION
Without the tracker passed in, frontend will not show error messages in autoform.